### PR TITLE
Tidy up GUI and cleanup in a few areas

### DIFF
--- a/AuthorProfile.cs
+++ b/AuthorProfile.cs
@@ -86,8 +86,9 @@ namespace XRayBuilderGUI
             }
             string percAuthorName = author.Replace(" ", "%20");
             string dashAuthorName = author.Replace(" ", "-");
+            string plusAuthorName = author.Replace(" ", "+");
             string amazonAuthorSearchUrl = @"http://www.amazon.com/s/?url=search-alias%3Dstripbooks&field-keywords=" +
-                                        percAuthorName;
+                                        plusAuthorName;
             main.Log("Searching for Author's page on Amazon...");
 
             // Search Amazon for Author
@@ -174,6 +175,7 @@ namespace XRayBuilderGUI
                 }
                 BioTrimmed = bio.InnerHtml.Replace("\"", "'");
                 BioTrimmed = Regex.Replace(BioTrimmed, @"<br><br>", " ", RegexOptions.IgnoreCase);
+                BioTrimmed = Regex.Replace(bio.InnerHtml, @"[ ]{2,}", " ", RegexOptions.IgnoreCase);
                 main.Log("Author biography found on Amazon!");
                 main.Log("Attempting to create Author Profile...");
             }
@@ -375,8 +377,7 @@ namespace XRayBuilderGUI
             if (bookImageLoc2 == null)
                 main.Log("Error finding book image. If you want, you can report the book's Amazon URL to help with parsing.");
             else
-                bookImageUrl = bookImageLoc2.GetAttributeValue("src", "");
-            //var bookImageUrl2 = Regex.Replace(bookImageLoc2.GetAttributeValue("src", ""), @"_.*?_\.", string.Empty);
+                bookImageUrl = Regex.Replace(bookImageLoc2.GetAttributeValue("src", ""), @"_.*?_\.", string.Empty);
 
             // Generate random book image URL because Amazon keep changing format!
             if (bookImageUrl == "")
@@ -404,8 +405,11 @@ namespace XRayBuilderGUI
                     if (nodeTitleCheck == "")
                     {
                         nodeTitle = item.SelectSingleNode(".//div/a");
-                        PurchAlsoBoughtTitles.Add(Regex.Replace(nodeTitle.InnerText, @"&#133;", "...",
-                            RegexOptions.Multiline));
+                        //Remove CR, LF and TAB
+                        string cleanTitle = Regex.Replace(nodeTitle.InnerText, @"\t|\n|\r", String.Empty);
+                        cleanTitle = cleanTitle.Trim();
+                        cleanTitle = Regex.Replace(cleanTitle, @"&#133;", "...");
+                        PurchAlsoBoughtTitles.Add(cleanTitle);
                     }
                     else
                     {

--- a/frmMain.cs
+++ b/frmMain.cs
@@ -18,7 +18,6 @@ namespace XRayBuilderGUI
         public bool Exiting = false;
         public bool BookFoundShelfari = false;
         public bool CheckTimestamp = false;
-        private bool _previewClear;
 
         private string currentLog = Environment.CurrentDirectory + @"\log\" +
                                     string.Format("{0:yyyy.MM.dd.hh.mm.ss}.txt", DateTime.Now);
@@ -48,6 +47,42 @@ namespace XRayBuilderGUI
             {
                 txtOutput.AppendText(message + "\r\n");
             }
+        }
+
+        private bool previewClear()
+        {
+            frmAP.lblTitle.Text = "";
+            frmAP.pbAuthorImage.Image = Properties.Resources.AI;
+            frmAP.lblBio1.Text = "";
+            frmAP.lblBio2.Text = "";
+            frmAP.lblKindleBooks.Text = "";
+            for (var i = 0; i < 4; i++)
+            {
+                foreach (Control contrl in frmAP.Controls)
+                {
+                    if (contrl.Name == ("lblBook" + (i + 1)))
+                    {
+                        contrl.Text = "";
+                    }
+                }
+            }
+            frmEA.lblPost.Text = "";
+            frmEA.lblMoreBooks.Text = "";
+            for (var i = 0; i < 5; i++)
+            {
+                foreach (Control contrl in frmEA.Controls)
+                {
+                    if (contrl.Name == ("lblBook" + (i + 1)))
+                    {
+                        contrl.Text = "";
+                    }
+                }
+            }
+            frmEA.lblBook6.Text = "";
+            frmEA.lblAuthor1.Text = "";
+            frmEA.lblBook7.Text = "";
+            frmEA.lblAuthor2.Text = "";
+            return true;
         }
         
         private void btnBrowseMobi_Click(object sender, EventArgs e)
@@ -470,30 +505,37 @@ namespace XRayBuilderGUI
                 aa = new AuthorProfile(results[5], results[4], results[0],
                     results[1], results[2], randomFile, Path.GetFileNameWithoutExtension(txtMobi.Text), this);
 
+            previewClear();
+
                 frmAP.lblTitle.Text = aa.ApTitle;
                 frmAP.pbAuthorImage.Image = aa.ApAuthorImage;
+
+                var g = Graphics.FromHwnd(frmAP.lblBio1.Handle);
+                int charFitted, linesFitted;
+                g.MeasureString(aa.BioTrimmed, frmAP.lblBio1.Font, frmAP.lblBio1.Size,
+                    StringFormat.GenericTypographic, out charFitted, out linesFitted);
+
                 if (aa.BioTrimmed != "")
                 {
-                    frmAP.lblBio1.Text = aa.BioTrimmed.Substring(0, Math.Min(aa.BioTrimmed.Length - 1, 315));
-                    if (aa.BioTrimmed.Length >= 655)
-                        frmAP.lblBio2.Text = aa.BioTrimmed.Substring(315, 340) + "...";
+                    if (aa.BioTrimmed.Length > charFitted)
+                    {
+                        string bio1Trim = aa.BioTrimmed.Substring(0, Math.Min(aa.BioTrimmed.Length, charFitted - 10));
+                        frmAP.lblBio1.Text = bio1Trim.Substring(0, bio1Trim.LastIndexOf(" "));
+                        frmAP.lblBio2.Text = aa.BioTrimmed.Substring(bio1Trim.LastIndexOf(" ") + 1);
+                    }
+                    else
+                    {
+                        frmAP.lblBio1.Text = aa.BioTrimmed;
+                    }
                 }
+
                 frmAP.lblKindleBooks.Text = aa.ApSubTitle;
                 for (var i = 0; i < Math.Min(aa.AuthorsOtherBookNames.Count - 1, 4); i++)
                 {
                     foreach (Control contrl in frmAP.Controls)
                     {
                         if (contrl.Name == ("lblBook" + (i + 1)))
-                        {
-                            if (aa.AuthorsOtherBookNames[i].Length > 40)
-                            {
-                                contrl.Text = aa.AuthorsOtherBookNames[i].Substring(0, 40);
-                            }
-                            else
-                            {
-                                contrl.Text = aa.AuthorsOtherBookNames[i];
-                            }
-                        }
+                            contrl.Text = aa.AuthorsOtherBookNames[i];
                     }
                 }
                 frmEA.lblPost.Text = String.Format("Post on Amazon (as {0})",
@@ -504,17 +546,8 @@ namespace XRayBuilderGUI
                     foreach (Control contrl in frmEA.Controls)
                     {
                         if (contrl.Name == ("lblBook" + (i + 1)))
-                        {
-                            if (aa.AuthorsOtherBookNames[i].Length > 40)
-                            {
-                                contrl.Text = aa.AuthorsOtherBookNames[i].Substring(0, 40);
-                            }
-                            else
-                            {
-                                contrl.Text = aa.AuthorsOtherBookNames[i];
-                            }
-                        }
-                    }
+                            contrl.Text = aa.AuthorsOtherBookNames[i];
+}
                 }
                 if (aa.PurchAlsoBoughtTitles.Count > 1 && aa.PpurchAlsoBoughtAuthorNames.Count > 1)
                 {

--- a/frmPreviewAP.Designer.cs
+++ b/frmPreviewAP.Designer.cs
@@ -50,9 +50,9 @@ namespace XRayBuilderGUI
             this.lblTitle.AutoEllipsis = true;
             this.lblTitle.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(242)))), ((int)(((byte)(242)))), ((int)(((byte)(242)))));
             this.lblTitle.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Bold);
-            this.lblTitle.Location = new System.Drawing.Point(18, 17);
+            this.lblTitle.Location = new System.Drawing.Point(23, 17);
             this.lblTitle.Name = "lblTitle";
-            this.lblTitle.Size = new System.Drawing.Size(265, 20);
+            this.lblTitle.Size = new System.Drawing.Size(260, 20);
             this.lblTitle.TabIndex = 68;
             this.lblTitle.Text = "About the Author ...Waiting...";
             this.lblTitle.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -89,6 +89,7 @@ namespace XRayBuilderGUI
             this.lblBook4.TabIndex = 74;
             this.lblBook4.Text = "Book 4 ...Waiting...";
             this.lblBook4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblBook4.UseMnemonic = false;
             // 
             // lblBook3
             // 
@@ -101,6 +102,7 @@ namespace XRayBuilderGUI
             this.lblBook3.TabIndex = 73;
             this.lblBook3.Text = "Book 3 ...Waiting...";
             this.lblBook3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblBook3.UseMnemonic = false;
             // 
             // lblBook2
             // 
@@ -113,6 +115,7 @@ namespace XRayBuilderGUI
             this.lblBook2.TabIndex = 72;
             this.lblBook2.Text = "Book 2 ...Waiting...";
             this.lblBook2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblBook2.UseMnemonic = false;
             // 
             // lblBook1
             // 
@@ -125,6 +128,7 @@ namespace XRayBuilderGUI
             this.lblBook1.TabIndex = 71;
             this.lblBook1.Text = "Book 1 ...Waiting...";
             this.lblBook1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblBook1.UseMnemonic = false;
             // 
             // lblKindleBooks
             // 
@@ -159,7 +163,7 @@ namespace XRayBuilderGUI
             this.pbAuthorImage.TabIndex = 75;
             this.pbAuthorImage.TabStop = false;
             // 
-            // frmPreviewAP
+            // FrmPreviewAp
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;

--- a/frmPreviewEA.Designer.cs
+++ b/frmPreviewEA.Designer.cs
@@ -57,6 +57,7 @@
             this.lblAuthor2.TabIndex = 98;
             this.lblAuthor2.Text = "Author";
             this.lblAuthor2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblAuthor2.UseMnemonic = false;
             // 
             // lblBook7
             // 
@@ -69,6 +70,7 @@
             this.lblBook7.TabIndex = 97;
             this.lblBook7.Text = "Book 2 ...Waiting...";
             this.lblBook7.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblBook7.UseMnemonic = false;
             // 
             // lblAuthor1
             // 
@@ -81,6 +83,7 @@
             this.lblAuthor1.TabIndex = 96;
             this.lblAuthor1.Text = "Author";
             this.lblAuthor1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblAuthor1.UseMnemonic = false;
             // 
             // lblBook6
             // 
@@ -93,6 +96,7 @@
             this.lblBook6.TabIndex = 95;
             this.lblBook6.Text = "Book 1 ...Waiting...";
             this.lblBook6.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblBook6.UseMnemonic = false;
             // 
             // lblBook5
             // 
@@ -105,6 +109,7 @@
             this.lblBook5.TabIndex = 94;
             this.lblBook5.Text = "Book 5 ...Waiting...";
             this.lblBook5.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblBook5.UseMnemonic = false;
             // 
             // lblBook4
             // 
@@ -117,6 +122,7 @@
             this.lblBook4.TabIndex = 93;
             this.lblBook4.Text = "Book 4 ...Waiting...";
             this.lblBook4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblBook4.UseMnemonic = false;
             // 
             // lblBook3
             // 
@@ -129,6 +135,7 @@
             this.lblBook3.TabIndex = 92;
             this.lblBook3.Text = "Book 3 ...Waiting...";
             this.lblBook3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblBook3.UseMnemonic = false;
             // 
             // lblBook2
             // 
@@ -141,6 +148,7 @@
             this.lblBook2.TabIndex = 91;
             this.lblBook2.Text = "Book 2 ...Waiting...";
             this.lblBook2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblBook2.UseMnemonic = false;
             // 
             // lblBook1
             // 
@@ -153,6 +161,7 @@
             this.lblBook1.TabIndex = 90;
             this.lblBook1.Text = "Book 1 ...Waiting...";
             this.lblBook1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblBook1.UseMnemonic = false;
             // 
             // label5
             // 
@@ -207,9 +216,9 @@
             // 
             this.lblTitle.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(242)))), ((int)(((byte)(242)))), ((int)(((byte)(242)))));
             this.lblTitle.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Bold);
-            this.lblTitle.Location = new System.Drawing.Point(18, 17);
+            this.lblTitle.Location = new System.Drawing.Point(21, 17);
             this.lblTitle.Name = "lblTitle";
-            this.lblTitle.Size = new System.Drawing.Size(265, 20);
+            this.lblTitle.Size = new System.Drawing.Size(260, 20);
             this.lblTitle.TabIndex = 85;
             this.lblTitle.Text = "Before you go...";
             this.lblTitle.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -223,7 +232,7 @@
             this.pbBackground.TabIndex = 84;
             this.pbBackground.TabStop = false;
             // 
-            // frmPreviewEA
+            // FrmPreviewEa
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;

--- a/frmPreviewXR.Designer.cs
+++ b/frmPreviewXR.Designer.cs
@@ -68,9 +68,9 @@
             this.lblTitle.AutoEllipsis = true;
             this.lblTitle.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(242)))), ((int)(((byte)(242)))), ((int)(((byte)(242)))));
             this.lblTitle.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Bold);
-            this.lblTitle.Location = new System.Drawing.Point(18, 17);
+            this.lblTitle.Location = new System.Drawing.Point(21, 17);
             this.lblTitle.Name = "lblTitle";
-            this.lblTitle.Size = new System.Drawing.Size(265, 20);
+            this.lblTitle.Size = new System.Drawing.Size(260, 20);
             this.lblTitle.TabIndex = 86;
             this.lblTitle.Text = "X-Ray";
             this.lblTitle.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;

--- a/frmSettings.Designer.cs
+++ b/frmSettings.Designer.cs
@@ -191,7 +191,7 @@
             this.chkUseNew.AutoSize = true;
             this.chkUseNew.Location = new System.Drawing.Point(255, 26);
             this.chkUseNew.Name = "chkUseNew";
-            this.chkUseNew.Size = new System.Drawing.Size(132, 17);
+            this.chkUseNew.Size = new System.Drawing.Size(137, 17);
             this.chkUseNew.TabIndex = 22;
             this.chkUseNew.Text = "Use New X-Ray Format";
             this.chkUseNew.UseVisualStyleBackColor = true;
@@ -331,6 +331,7 @@
             // chkSendToKindle
             // 
             this.chkSendToKindle.AutoSize = true;
+            this.chkSendToKindle.Enabled = false;
             this.chkSendToKindle.Location = new System.Drawing.Point(9, 95);
             this.chkSendToKindle.Name = "chkSendToKindle";
             this.chkSendToKindle.Size = new System.Drawing.Size(158, 17);
@@ -466,9 +467,9 @@
             this.lblVersion.AutoSize = true;
             this.lblVersion.Cursor = System.Windows.Forms.Cursors.Hand;
             this.lblVersion.ForeColor = System.Drawing.SystemColors.ControlDark;
-            this.lblVersion.Location = new System.Drawing.Point(283, 393);
+            this.lblVersion.Location = new System.Drawing.Point(281, 393);
             this.lblVersion.Name = "lblVersion";
-            this.lblVersion.Size = new System.Drawing.Size(130, 13);
+            this.lblVersion.Size = new System.Drawing.Size(135, 13);
             this.lblVersion.TabIndex = 32;
             this.lblVersion.Text = "X-Ray Builder GUI v0.0.0.0";
             this.lblVersion.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;

--- a/frmSettings.cs
+++ b/frmSettings.cs
@@ -79,10 +79,15 @@ namespace XRayBuilderGUI
             toolTip1.SetToolTip(chkSoftHyphen,
                 "Ignore soft hyphens (Unicode U+00AD) while searching\r\nfor terms. This may slow down the parsing process slightly.");
             toolTip1.SetToolTip(chkUseNew,
-                "Write the X-Ray file in the new format for Paperwhite 2\r\nor Voyage firmware 5.6+.\r\nIf you have one of these devices but this does not work, try the old format.");
+                "Write the X-Ray file in the new format for\r\n" +
+                "Paperwhite 2 or Voyage firmware 5.6+. If\r\n" +
+                "you have one of these devices but this\r\n" +
+                "does notwork, try the old format.");
             toolTip1.SetToolTip(chkAndroid,
                 "Changes the naming convention of the X-Ray file for the\r\nAndroid Kindle app. Forces building with the new format.");
-            toolTip1.SetToolTip(chkUTF8, "Write the X-Ray file in UTF8 instead of ANSI.\r\nUse this option if there are accented characters in your book, the title, or author's name.");
+            toolTip1.SetToolTip(chkUTF8, "Write the X-Ray file in UTF8 instead of ANSI.\r\n" +
+                "Use this option if there are accented characters\r\n" +
+                "in your book, the title, or author's name.");
             toolTip1.SetToolTip(txtReal, "Required during the EndActions.data file\r\n" +
                                          "creation. This information allows you to\r\n" +
                                          "rate this book on Amazon.");
@@ -93,13 +98,15 @@ namespace XRayBuilderGUI
                 "Search Amazon.co.uk first, use Amazon.com as fallback.\r\n(Amazon.com is used if Amazon.co.uk is not selected.)");
             toolTip1.SetToolTip(chkEnableEdit,
                 "Open Notepad to enable editing of detected Chapters\r\nand Aliases before final X-Ray creation.");
-            toolTip1.SetToolTip(chkSubDirectories, "Save generated files to an \"Author\\Filename.sdr\" subdirectory.");
+            toolTip1.SetToolTip(chkSubDirectories, "Save generated files to an\r\n" +
+                                         "\"Author\\Filename.sdr\" subdirectory.");
             toolTip1.SetToolTip(btnLogs, "Open the log files directory.");
             toolTip1.SetToolTip(chkOverwrite,
                 "Overwrite exiting AuthorProfile and\r\nEndActions files, if they exist.");
             toolTip1.SetToolTip(chkSendToKindle,
                 "Automatically send to your Kindle documents folder\r\nif your Kindle is connected when files are generated.");
-            toolTip1.SetToolTip(chkSaveHtml, "Save parsed HTML files. This is generally used\r\n for debugging and can be left unchecked");
+            toolTip1.SetToolTip(chkSaveHtml, "Save parsed HTML files. This is generally used\r\n" +
+                                         "for debugging and can be left unchecked.");
             toolTip1.SetToolTip(btnHelp, "View the included help documentation.");
         }
 


### PR DESCRIPTION
-Changed author name separator to "+" during Amazon search, seems this
is what Amazon is using.
-Replace double spaces in author biography.
-Removed trimming of book names and use labels AutoEllipsis capability
in the previews.
-Remove CR, LF and TAB from <recs type="purchase"><title> names.
-Remove extra junk in Amazon book image URL.
-Minor tweaks to GUI previews.
-Set UseMnemonic = false on preview GUIs so "&" displays correctly.
-Minor changes to tool tips on settings GUI.
-Disabled "Send to Kindle" as it's not implemented yet.
-Tried to improve the wrapping of author biography in the preview.
-Clear previews for each new book.