### PR TITLE
Fix for changes to Amazon page layout etc.

### DIFF
--- a/AuthorProfile.cs
+++ b/AuthorProfile.cs
@@ -99,7 +99,6 @@ namespace XRayBuilderGUI
                 catch (Exception ex)
                 {
                     main.Log(String.Format("An error ocurred saving authorsearchHtml.txt: {0}", ex.Message));
-                    return;
                 }
             }
 
@@ -148,7 +147,6 @@ namespace XRayBuilderGUI
                 catch (Exception ex)
                 {
                     main.Log(String.Format("An error ocurred saving authorpageHtml.txt: {0}", ex.Message));
-                    return;
                 }
             }
 
@@ -262,25 +260,30 @@ namespace XRayBuilderGUI
             main.Log("Gathering author's other books...");
             List<BookInfo> bookList = new List<BookInfo>();
             HtmlNodeCollection resultsNodes =
-                authorHtmlDoc.DocumentNode.SelectNodes("//div[@id='mainResults']/div");
+                authorHtmlDoc.DocumentNode.SelectNodes("//div[@id='mainResults']/ul/li");
             foreach (HtmlNode result in resultsNodes)
             {
                 if (!result.Id.StartsWith("result_")) continue;
                 string name, url, asin = "";
-                HtmlNode otherBook = result.SelectSingleNode(".//div/h3/a/@href");
+                HtmlNode otherBook = result.SelectSingleNode(".//div[@class='a-row a-spacing-small']/a/h2");
                 Match match = Regex.Match(otherBook.InnerText, @"Series Reading Order|Edition|eSpecial", RegexOptions.IgnoreCase);
                 if (match.Success)
                 {
                     continue;
                 }
                 name = otherBook.InnerText;
-                url = otherBook.GetAttributeValue("href", "");
-                otherBook = result.SelectSingleNode(".//*[@class='tpType']");
-                int index = otherBook.OuterHtml.IndexOf("/dp/B");
-                if (index != -1 && otherBook.InnerText.Contains("Kindle Edition"))
+                otherBook = result.SelectSingleNode(".//*[@title='Kindle Edition']");
+                match = Regex.Match(otherBook.OuterHtml, "dp/(B[A-Z0-9]{9})/");
+                if (match.Success)
                 {
-                    asin = otherBook.OuterHtml.Substring(index + 4, 10);
+                    asin = match.Groups[1].Value;
                 }
+                //url = otherBook.GetAttributeValue("href", "");
+                //url = otherBook.GetAttributeValue("href", "").
+                //    Substring(0, otherBook.GetAttributeValue("href", "").
+                //    IndexOf(match.Groups[1].Value) +
+                //    match.Groups[1].Length);
+                url = String.Format("http://www.amazon.com/dp/{0}", asin);
                 if (name != "" && url != "" && asin != "")
                 {
                     BookInfo newBook = new BookInfo(name, curBook.author, asin);
@@ -341,26 +344,6 @@ namespace XRayBuilderGUI
             ApAuthorImage = Image.FromFile(curBook.path + @"\FinalImage.jpg");
             EaSubTitle = "More Books By " + curBook.author;
 
-            
-            /*try
-            {
-                if (settings.sendtoKindle)
-                {
-                    if (Directory.Exists(settings.docDir))
-                    {
-                        File.Copy(ApPath, ApDest, true);
-                        main.Log("Author Profile file successfully copied to your Kindle!");
-                        File.Copy(EaPath, EaDest, true);
-                        main.Log("End Action file successfully copied to your Kindle!");
-                    }
-                    main.Log("Specified Kindle cocuments folder not found. Is your Kindle connected?" +
-                             " If so, please review the settings page.");
-                }
-            }
-            catch (Exception ex)
-            {
-                main.Log("An error occured copying files to your Kindle!\r\nException: " + ex.Message);
-            }*/
             complete = true;
         }
 

--- a/EndActions.cs
+++ b/EndActions.cs
@@ -62,13 +62,12 @@ namespace XRayBuilderGUI
                 try
                 {
                     File.WriteAllText(Environment.CurrentDirectory +
-                                      String.Format(@"\dmp\{0}.bookHtml.txt", book.asin),
-                        ap.authorHtmlDoc.DocumentNode.InnerHtml);
+                                      String.Format(@"\dmp\{0}.bookpageHtml.txt", curBook.asin),
+                        bookHtmlDoc.DocumentNode.InnerHtml);
                 }
                 catch (Exception ex)
                 {
-                    main.Log(String.Format("An error ocurred saving bookHtml.txt: {0}", ex.Message));
-                    return;
+                    main.Log(String.Format("An error ocurred saving bookpageHtml.txt: {0}", ex.Message));
                 }
             }
 
@@ -275,8 +274,10 @@ namespace XRayBuilderGUI
             string seriesPosition = curBook.seriesPosition == "" ? "" :
                 String.Format(@"""seriesPosition"":{{""class"":""seriesPosition"",""positionInSeries"":{0},""totalInSeries"":{1},""seriesName"":""{2}""}},",
                     curBook.seriesPosition, curBook.totalInSeries, curBook.seriesName);
-            string popularHighlights = String.Format(@"""popularHighlightsText"":{{""class"":""dynamicText"",""localizedText"":{{""de"":""{0} Passagen wurden {1} mal markiert"",""en-US"":""{0} passages have been highlighted {1} times"",""ru"":""1\u00A0095 \u043E\u0442\u0440\u044B\u0432\u043A\u043E\u0432 \u0431\u044B\u043B\u043E \u0432\u044B\u0434\u0435\u043B\u0435\u043D\u043E 12\u00A0326 \u0440\u0430\u0437"",""pt-BR"":""{0} trechos foram destacados {1} vezes"",""ja"":""{0}\u7B87\u6240\u304C{1}\u56DE\u30CF\u30A4\u30E9\u30A4\u30C8\u3055\u308C\u307E\u3057\u305F"",""en"":""{0} passages have been highlighted {1} times"",""it"":""{0} brani sono stati evidenziati {1} volte"",""fr"":""{0}\u00A0095 passages ont \u00E9t\u00E9 surlign\u00E9s {1}\u00A0326 fois"",""zh-CN"":""{0} \u4E2A\u6BB5\u843D\u88AB\u6807\u6CE8\u4E86 {1} \u6B21"",""es"":""Se han subrayado {0} pasajes {1} veces"",""nl"":""{0} fragmenten zijn {1} keer gemarkeerd""}}}}", curBook.popularPassages, curBook.popularHighlights);
-            string grokShelfInfo = String.Format(@"""grokShelfInfo"":{{""class"":""goodReadsShelfInfo"",""asin"":""{0}"",""shelves"":[""reading""]}}", curBook.asin);
+
+            string popularHighlights = curBook.popularHighlights == "" ? "" :
+                String.Format(@"""popularHighlightsText"":{{""class"":""dynamicText"",""localizedText"":{{""de"":""{0} Passagen wurden {1} mal markiert"",""en-US"":""{0} passages have been highlighted {1} times"",""ru"":""1\u00A0095 \u043E\u0442\u0440\u044B\u0432\u043A\u043E\u0432 \u0431\u044B\u043B\u043E \u0432\u044B\u0434\u0435\u043B\u0435\u043D\u043E 12\u00A0326 \u0440\u0430\u0437"",""pt-BR"":""{0} trechos foram destacados {1} vezes"",""ja"":""{0}\u7B87\u6240\u304C{1}\u56DE\u30CF\u30A4\u30E9\u30A4\u30C8\u3055\u308C\u307E\u3057\u305F"",""en"":""{0} passages have been highlighted {1} times"",""it"":""{0} brani sono stati evidenziati {1} volte"",""fr"":""{0}\u00A0095 passages ont \u00E9t\u00E9 surlign\u00E9s {1}\u00A0326 fois"",""zh-CN"":""{0} \u4E2A\u6BB5\u843D\u88AB\u6807\u6CE8\u4E86 {1} \u6B21"",""es"":""Se han subrayado {0} pasajes {1} veces"",""nl"":""{0} fragmenten zijn {1} keer gemarkeerd""}}}}", curBook.popularPassages, curBook.popularHighlights);
+            string grokShelfInfo = String.Format(@"""grokShelfInfo"":{{""class"":""goodReadsShelfInfo"",""asin"":""{0}"",""shelves"":[""to-read""]}}", curBook.asin);
             string currentBook = curBook.ToExtraJSON("featuredRecommendation");
             string authors = String.Format(@"""authorBios"":{{""class"":""authorBioList"",""authors"":[{0}]}}", authorProfile.ToJSON());
             string authorRecs = @"""authorRecs"":{{""class"":""recommendationList"",""recommendations"":[{0}]}}";

--- a/XRay.cs
+++ b/XRay.cs
@@ -81,7 +81,7 @@ namespace XRayBuilderGUI
             "Sig Ra", "Sir", "Sister", "Sqn Ldr", "Sr", "Sr D", "Sra", "Srta", "Sultan", "Tan Sri", "Tan Sri Dato",
             "Tengku", "Teuku", "Than Puying", "The Hon Dr", "The Hon Justice", "The Hon Miss", "The Hon Mr",
             "The Hon Mrs", "The Hon Ms", "The Hon Sir", "The Very Rev", "Toh Puan", "Tun", "Vice Admiral",
-            "Viscount", "Viscountess", "Wg Cdr", "Jr", "Sr" };
+            "Viscount", "Viscountess", "Wg Cdr", "Jr", "Sr", "Sheriff", "Special Agent" };
         #endregion
 
         public XRay()
@@ -957,6 +957,7 @@ namespace XRayBuilderGUI
             //Try to remove common titles from aliases
             using (var streamWriter = new StreamWriter(aliasFile, false, Encoding.UTF8))
             {
+                List<string> aliasCheck = new List<string>();
                 foreach (var c in Terms)
                     if (c.Type == "character")
                     {
@@ -968,13 +969,19 @@ namespace XRayBuilderGUI
                             List<string> aliasList = new List<string>();
                             TextInfo textInfo = new CultureInfo("en-US", false).TextInfo;
                             
-                            string pattern = @"( ?(" + string.Join("|", CommonTitles) + ")\\. ?)|(^[A-Z]\\. )|( [A-Z]\\.)|(\\\\\")|(“)|(”)";
+                            string pattern = @"( ?(" + string.Join("|", CommonTitles) + ")\\.? )|(^[A-Z]\\. )|( [A-Z]\\.)|(\")|(“)|(”)|(,)";
 
-                            Regex regex = new Regex(pattern, RegexOptions.IgnoreCase);
-                            Match matchCheck = Regex.Match(c.TermName, pattern , RegexOptions.IgnoreCase);
+                            Regex regex = new Regex(pattern);
+                            Match matchCheck = Regex.Match(c.TermName, pattern);
                             if (matchCheck.Success)
                             {
                                 titleTrimmed = c.TermName;
+                                titleTrimmed = Regex.Replace(titleTrimmed, @"\s+", " ");
+                                titleTrimmed = Regex.Replace(titleTrimmed, @"( ?V?I{0,3}$)", String.Empty);
+                                foreach (Match match in regex.Matches(titleTrimmed))
+                                {
+                                    titleTrimmed = titleTrimmed.Replace(match.Value, String.Empty);
+                                }
                                 foreach (Match match in regex.Matches(titleTrimmed))
                                 {
                                     titleTrimmed = titleTrimmed.Replace(match.Value, String.Empty);
@@ -1000,6 +1007,9 @@ namespace XRayBuilderGUI
                                 aliasList.Sort((a, b) => b.Length.CompareTo(a.Length));
                                 foreach (string word in aliasList)
                                 {
+                                    if (aliasCheck.Any(str => str.Equals(word)))
+                                        continue;
+                                    aliasCheck.Add(word);
                                     splitName += word + ",";
                                 }
                                 streamWriter.WriteLine(c.TermName + "|" + splitName.Substring(0, splitName.LastIndexOf(",")));


### PR DESCRIPTION
- Fixed saving HTML error which could cause processes to abort.
- Don't write popularHighlights to SA if there are none, would cause SA
to fail to open properly on Kindle.
- Change node selection for AP.
- Remove unused sendtoKindle code.
- More work on alias splitting to remove duplicates etc.