### PR TITLE
Fix: Removed comma from "all reviews" number

### DIFF
--- a/src/BookInfo.cs
+++ b/src/BookInfo.cs
@@ -173,7 +173,7 @@ namespace XRayBuilderGUI
                         {
                             Match match = Regex.Match(reviewsNode.InnerText, @"(\d+,\d+)|(\d+)");
                             if (match.Success)
-                                numReviews = int.Parse(match.Value, NumberStyles.AllowThousands);
+                                numReviews = int.Parse(match.Value.Substring(0, reviewsNode.InnerText.IndexOf(' ')).Replace(",", ""), NumberStyles.AllowThousands);
                             return;
                         }
                         numReviews = int.Parse(reviewsNode.InnerText.Substring(0, reviewsNode.InnerText.IndexOf(' ')).Replace(",", ""));

--- a/src/DataSources/Goodreads.cs
+++ b/src/DataSources/Goodreads.cs
@@ -247,10 +247,11 @@ namespace XRayBuilderGUI.DataSources
             if (metaNode != null)
             {
                 HtmlNode passagesNode = metaNode.SelectSingleNode(".//a[@class='actionLinkLite votes' and @href='#other_reviews']");
-                match = Regex.Match(passagesNode.InnerText, @"(\d+,\d+)|(\d+)");
+                match = Regex.Match(passagesNode.InnerText, @"(\d+,\d+,\d+)|(\d+,\d+)|(\d+)");
                 if (match.Success)
                 {
-                    passages = int.Parse(match.Value, NumberStyles.AllowThousands);                    
+                    string tempStrg = match.Value.Replace(",", ""); //Remove all commas from value
+                    passages = int.Parse(tempStrg, NumberStyles.AllowThousands);                    
                 }
                 if (passages == 0 || passages < 10)
                 {
@@ -263,10 +264,11 @@ namespace XRayBuilderGUI.DataSources
                 curBook.popularPassages = passages.ToString();
 
                 HtmlNode highlightsNode = metaNode.SelectSingleNode(".//a[@class='actionLinkLite' and @href='#other_reviews']");
-                match = Regex.Match(highlightsNode.InnerText, @"(\d+,\d+)|(\d+)");
+                match = Regex.Match(highlightsNode.InnerText, @"(\d+,\d+,\d+)|(\d+,\d+)|(\d+)");
                 if (match.Success)
                 {
-                    highlights = int.Parse(match.Value, NumberStyles.AllowThousands);                    
+                    string tempStrg = match.Value.Replace(",", ""); //Remove all commas from value
+                    highlights = int.Parse(tempStrg, NumberStyles.AllowThousands);                    
                 }
                 if (highlights == 0 || highlights < 10)
                 {
@@ -303,10 +305,11 @@ namespace XRayBuilderGUI.DataSources
                     curBook.amazonRating = float.Parse(goodreadsRating.InnerText);
                 }
                 HtmlNode passagesNode = metaNode.SelectSingleNode(".//a[@class='actionLinkLite votes' and @href='#other_reviews']");
-                match = Regex.Match(passagesNode.InnerText, @"(\d+,\d+)|(\d+)");
+                match = Regex.Match(passagesNode.InnerText, @"(\d+,\d+,\d+)|(\d+,\d+)|(\d+)");
                 if (match.Success)
                 {
-                    curBook.numReviews = int.Parse(match.Value, NumberStyles.AllowThousands);
+                    string tempStrg = match.Value.Replace(",", ""); //Remove all commas from value
+                    curBook.numReviews = int.Parse(tempStrg, NumberStyles.AllowThousands);
                 }
             }
 


### PR DESCRIPTION
Hi!
When I was using this software I had an error at runtime:
![error1](https://cloud.githubusercontent.com/assets/4419930/21553637/7fc7b084-cdf0-11e6-8477-01e1c7aaf5fb.PNG)

So, I forked the project and started debuging it, the problem was that the value was coming with a comma, as you can see:
![error1_det](https://cloud.githubusercontent.com/assets/4419930/21553684/df7b5044-cdf0-11e6-85b5-a44056d13b8c.png)

So, I've copied the code from some lines below that remove commas and the code worked as expected!

And fixed regex (in Goodreads.cs) for books that have more than 1M passages and highlights.